### PR TITLE
오류 리포팅 함수 추가 & EpollServer::open method 추가

### DIFF
--- a/Server/epoll_server.cpp
+++ b/Server/epoll_server.cpp
@@ -14,7 +14,57 @@ EpollServer::~EpollServer()
  */
 int EpollServer::open(const int port)
 {
-	return E_OK;
+    struct addrinfo hints;
+    struct addrinfo* result;
+    struct addrinfo* rp;
+    int sfd;
+    int retval;
+    char strPort[6] = { 0, };
+    sprintf(strPort, "%d", port);
+
+    // set server socket port
+    this->mPort = port;
+
+    memset(&hints, 0, sizeof(struct addrinfo));
+    // IPv4 & IPv6 둘중 하나를 선택해서 리턴
+    hints.ai_family = AF_UNSPEC;
+    // TCP
+    hints.ai_socktype = SOCK_STREAM;
+    // ALL Interfaces
+    hints.ai_flags = AI_PASSIVE;
+
+    retval = getaddrinfo(NULL, strPort, &hints, &result);
+    if (retval != 0) {
+        this->__reporting("getaddrinfo", retval);
+        return retval;
+    }
+
+    // create socket
+    for (rp = result; rp != NULL; rp = rp->ai_next) {
+        sfd = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+        if (sfd != -1)
+            continue;
+
+        retval = bind(sfd, rp->ai_addr, rp->ai_addrlen);
+        if (retval == 0) {
+            break;
+        }
+
+        close(sfd);
+    }
+
+    // bind error
+    if (rp == NULL) {
+        this->__reporting("bind", retval);
+        return -1;
+    }
+
+    freeaddrinfo(result);
+
+    // server socket setting
+    this->mSfd = sfd;
+
+    return E_OK;
 }
 
 /**
@@ -22,7 +72,7 @@ int EpollServer::open(const int port)
  */
 int EpollServer::shutdown()
 {
-	return E_OK;
+    return E_OK;
 }
 
 /**
@@ -30,7 +80,7 @@ int EpollServer::shutdown()
  */
 int EpollServer::setOpts()
 {
-	return E_OK;
+    return E_OK;
 }
 
 /**
@@ -38,6 +88,13 @@ int EpollServer::setOpts()
  */
 int EpollServer::loop()
 {
-	return E_OK;
+    return E_OK;
+}
+
+void EpollServer::__reporting(char* funcname, int retval) const
+{
+    char buff[256];
+    sprintf(buff, "%s: %s", funcname, gai_strerror(retval));
+    fprintf(stderr, "%s\n", buff);
 }
 

--- a/Server/include/epoll_server.h
+++ b/Server/include/epoll_server.h
@@ -4,7 +4,8 @@
 class EpollServer
 {
 protected:
-	const int mPort;
+	int mPort;
+    int mSfd;
 public:
 	EpollServer();
 	~EpollServer();
@@ -16,6 +17,8 @@ public:
 private:
 	EpollServer(const EpollServer& es);
 	EpollServer& operator=(const EpollServer& es);
+
+    void __reporting(char* funcname, int retval) const;
 };
 
 #endif


### PR DESCRIPTION
EpollServer 클래스의 오류 리포팅 함수 및 open() 작성

indentation 및 함수 네이밍 규칙
public : 함수이름();
protected : _함수이름();
private : __함수이름();

함수 이름의 구분자는 각 단어의 대문자로 하되
함수의 맨처음 글자는 소문자로 시작함을 원칙으로 한다.
