### PR TITLE
EPollServer Class epoll 관련 method 구현

### DIFF
--- a/Server/epoll_server.cpp
+++ b/Server/epoll_server.cpp
@@ -185,7 +185,7 @@ int EpollServer::loop()
                     }
 
                     // accept handler
-                    this->accept(event, hbuf, sbuf);
+                    this->mHandler->accept(event, hbuf, sbuf);
                 }
             } else if (current_event.events & EPOLLIN) {
                 // read data
@@ -193,13 +193,13 @@ int EpollServer::loop()
                 int nread = read(current_event.data.fd, buf, MAX_BUFFER_SIZE);
                 if (nread < 1) {
                     // closed connection on descriptor
-                    this->disconnect(current_event);
+                    this->mHandler->disconnect(current_event);
                 } else {
                     // NULL value setting
                     if (nread < MAX_BUFFER_SIZE) buf[nread] = 0;
 
                     // recv event!!
-                    this->recv(current_event, buf, nread);
+                    this->mHandler->recv(current_event, buf, nread);
                 }
             } else if (current_event.events & EPOLLOUT) {
                 // write event!!

--- a/Server/epoll_server.cpp
+++ b/Server/epoll_server.cpp
@@ -1,8 +1,10 @@
 #include "include/global.h"
+#include "include/server_handler.h"
 #include "include/epoll_server.h"
 
-EpollServer::EpollServer()
+EpollServer::EpollServer(ServerHandler* handler)
 {
+    this->mHandler = handler;
 }
 
 EpollServer::~EpollServer()
@@ -111,7 +113,7 @@ int EpollServer::listen()
 int EpollServer::_epoll_init(const int epollsize)
 {
 	int retval = 0;
-    int epfd = epoll_create(epollsize);
+    this->mEpfd = epoll_create(epollsize);
     if (epfd == -1) {
         this->__reporting("epoll_create", "can't create epoll events");
 		return -1;
@@ -133,6 +135,77 @@ int EpollServer::_epoll_init(const int epollsize)
  */
 int EpollServer::loop()
 {
+    int retval = 0;
+    epoll_event event, current_event;
+
+    for (;;) {
+        int n = epoll_wait(this->mEpfd, this->mEvents, MAX_EVENTS, -1);
+        for (int i = 0; i < n; i++) {
+            current_event = this->mEvents[i];
+
+            if ((current_event.events & EPOLLERR) ||
+                (current_event.events & EPOLLHUP) ||
+               !(current_event.events & EPOLLIN)) {
+                // epoll error!!
+                this->mHandler->disconnect(current_event);
+            } else if (current_event.events & EPOLLRDHUP) {
+                // closed connection on descriptor via EPOLLRDHUP
+                this->mHandler->disconnect(current_event);
+            } else if (this->mSfd == current_event.data.fd) {
+                // listening socket
+                for (;;) {
+                    sockaddr in_addr;
+                    sockaddr sa;
+                    socklen_t in_len;
+                    int infd;
+                    char hbuf[NI_MAXHOST], sbuf[NI_MAXSERV];
+
+                    in_len = sizeof(in_addr);
+                    infd = accept4(this->mSfd, &in_addr, &in_len, SOCK_NONBLOCK, SOCK_CLOEXEC);
+                    if (infd == -1) {
+                        if (errno == EAGAIN || errno == EWOULDBLOCK)
+                            break;
+                        else {
+                            // accept!!
+                            break;
+                        }
+                    }
+
+                    retval = getnameinfo(&sa, in_len, hbuf, sizeof(hbuf), sbuf, sizeof(sbuf), NI_NUMERICHOST | NI_NUMERICSERV);
+                    if (retval == 0) {
+                        // host = hbuf, serv = sbuf
+                    }
+
+                    event.data.fd = infd;
+                    event.events  = EPOLLIN | EPOLLRDHUP | EPOLLET;
+                    retval = epoll_ctl(this->mEpfd, EPOLL_CTL_ADD, infd, &event);
+                    if (retval == -1) {
+                        this->__reporting("epoll_ctl", "Register for read events error");
+                        return -1;
+                    }
+
+                    // accept handler
+                    this->accept(event, hbuf, sbuf);
+                }
+            } else if (current_event.events & EPOLLIN) {
+                // read data
+                char buf[MAX_BUFFER_SIZE];
+                int nread = read(current_event.data.fd, buf, MAX_BUFFER_SIZE);
+                if (nread < 1) {
+                    // closed connection on descriptor
+                    this->disconnect(current_event);
+                } else {
+                    // NULL value setting
+                    if (nread < MAX_BUFFER_SIZE) buf[nread] = 0;
+
+                    // recv event!!
+                    this->recv(current_event, buf, nread);
+                }
+            } else if (current_event.events & EPOLLOUT) {
+                // write event!!
+            }
+        }
+    }
     return E_OK;
 }
 

--- a/Server/epoll_server.cpp
+++ b/Server/epoll_server.cpp
@@ -81,19 +81,19 @@ int EpollServer::shutdown()
  */
 int EpollServer::setOpts()
 {
-	int flags, s;
-	flags = fcntl(this->mSfd, FGETFL, 0);
-	if (flags == -1) {
-		this->__reporting("fcntl", "none-blocking socket option getting error");
-		return -1;
-	}
+    int flags, s;
+    flags = fcntl(this->mSfd, FGETFL, 0);
+    if (flags == -1) {
+        this->__reporting("fcntl", "none-blocking socket option getting error");
+        return -1;
+    }
 
-	flags |= O_NONBLOCK;
-	s = fcntl(this->mSfd, F_SETFL, flags);
-	if (s == -1) {
-		this->__reporting("1:fcntl", "none-blocking socket change error");
-		return -1;
-	}
+    flags |= O_NONBLOCK;
+    s = fcntl(this->mSfd, F_SETFL, flags);
+    if (s == -1) {
+        this->__reporting("1:fcntl", "none-blocking socket change error");
+        return -1;
+    }
     return E_OK;
 }
 /**
@@ -101,8 +101,8 @@ int EpollServer::setOpts()
  */
 int EpollServer::listen()
 {
-	int ret = listen(this->mSfd, SOMAXCONN);
-	return E_OK;
+    int ret = listen(this->mSfd, SOMAXCONN);
+    return E_OK;
 }
 
 /**
@@ -110,7 +110,22 @@ int EpollServer::listen()
  */
 int EpollServer::_epoll_init(const int epollsize)
 {
-	return E_OK;
+	int retval = 0;
+    int epfd = epoll_create(epollsize);
+    if (epfd == -1) {
+        this->__reporting("epoll_create", "can't create epoll events");
+		return -1;
+    }
+
+    epoll_event event;
+    event.data.fd = this->mSfd;
+    event.events  = EPOLLIN | EPOLLET;
+    retval = epoll_ctl(epfd, EPOLL_CTL_ADD, this->mSfd, &event);
+    if (retval == -1) {
+        this->__reporting("epoll_ctl", "can't create epoll events");
+        return -1;
+    }
+    return E_OK;
 }
 
 /**

--- a/Server/include/epoll_server.h
+++ b/Server/include/epoll_server.h
@@ -4,32 +4,35 @@
 class EpollServer
 {
 private:
-	enum Config {
-		MAX_EVENTS = 64,
-		MAX_BUFFER_SIZE = 512
-	};
+    enum Config {
+        MAX_EVENTS = 64,
+        MAX_BUFFER_SIZE = 512
+    };
 protected:
-	int mPort;
+    int mPort;
     int mSfd;
+    int mEpfd;
 
-	epoll_event mEvents[MAX_EVENTS];
+    epoll_event mEvents[MAX_EVENTS];
+
+    ServerHandler* mHandler;
 
 public:
-	EpollServer();
-	~EpollServer();
+    EpollServer(ServerHandler* handler);
+    ~EpollServer();
 
-	int open(const int port);
-	int shutdown();
-	int setOpts();
-	int listen();
-	int loop();
+    int open(const int port);
+    int shutdown();
+    int setOpts();
+    int listen();
+    int loop();
 
 protected:
-	int _epoll_init(const int epollsize);
+    int _epoll_init(const int epollsize);
 
 private:
-	EpollServer(const EpollServer& es);
-	EpollServer& operator=(const EpollServer& es);
+    EpollServer(const EpollServer& es);
+    EpollServer& operator=(const EpollServer& es);
 
     void __reporting(char* funcname, int retval) const;
 };

--- a/Server/include/server_handler.h
+++ b/Server/include/server_handler.h
@@ -1,0 +1,17 @@
+#ifndef SERVER_HANDLER_H_
+#define SERVER_HANDLER_H_
+
+class ServerHandler
+{
+public:
+    ServerHandler()  {}
+    virtual ~ServerHandler() {}
+
+    virtual void accept(epoll_event& event, const char* hbuf, const char* sbuf) = 0;
+    virtual void disconnect(epoll_event& event) = 0;
+    virtual void recv(epoll_event& event, const char* buffer, int readlen) = 0;
+    virtual void send(epoll_event& event) = 0;
+};
+
+#endif
+


### PR DESCRIPTION
EpollServer Class의 epoll 관련 초기화 및 루프 관련 method 구현
ServerHandler Abstract Class 선언

추후 서버쪽 구현시 ServerHandler 클래스를 상속받아 각종 가상 함수들을 구현한 뒤
EpollServer의 생성자의 인자값으로 Handler Class를 넘겨주면 되는 방식으로 구현

추후 클라이언트측 관련 부분도 업데이트 예정
